### PR TITLE
feat: display costs for registration using proxy or sudo

### DIFF
--- a/src/CostSummary/CostSummary.tsx
+++ b/src/CostSummary/CostSummary.tsx
@@ -19,7 +19,8 @@ export const CostSummary: React.FC<CostSummaryProps> = ({ fees, deposit, account
   const isProxyUsed = proxiedAccountBalance !== undefined;
 
   const hasInsufficientFunds = !isProxyUsed && accountBalance < totalCost;
-  const hasProxyInsufficientFunds = isProxyUsed && proxiedAccountBalance < totalCost;
+  const hasProxyInsufficientFunds = isProxyUsed && proxiedAccountBalance < deposit;
+  const hasSignerInsufficientFunds = isProxyUsed && accountBalance < fees;
 
   return (
     <div className="mt-6 bg-gray-100 border border-gray-300 rounded-lg p-4">
@@ -31,7 +32,7 @@ export const CostSummary: React.FC<CostSummaryProps> = ({ fees, deposit, account
           <h3 className="text-lg font-semibold">Cost Summary</h3>
         </div>
         <div className="flex items-center space-x-2">
-          {hasInsufficientFunds || hasProxyInsufficientFunds ? (
+          {hasInsufficientFunds || (hasProxyInsufficientFunds ||  hasSignerInsufficientFunds) ? (
             <div className="flex items-center space-x-2">
               <span className="text-red-600 font-medium">fails</span>
               <ErrorIcon size={8} />
@@ -59,7 +60,13 @@ export const CostSummary: React.FC<CostSummaryProps> = ({ fees, deposit, account
                 <div className="p-3 bg-red-100 border-l-4 border-red-500 text-red-700 rounded mt-3">
                   <p className="font-semibold">Insufficient Funds</p>
                   <p>The proxied account doesn't have enough balance.</p>
-                  <p>You need at least <span className="font-bold">{formatCurrency(totalCost, chainProperties.tokenDecimals)} {chainProperties.tokenSymbol}</span> in the proxied account.</p>
+                  <p>You need at least <span className="font-bold">{formatCurrency(deposit, chainProperties.tokenDecimals)} {chainProperties.tokenSymbol}</span> in the proxied account.</p>
+                </div>
+              ) : null}
+               {hasSignerInsufficientFunds ? (
+                <div className="p-3 bg-red-100 border-l-4 border-red-500 text-red-700 rounded mt-3">
+                  <p className="font-semibold">Insufficient Funds</p>
+                  <p>You need at least <span className="font-bold">{formatCurrency(fees, chainProperties.tokenDecimals)} {chainProperties.tokenSymbol}</span> to complete this transaction.</p>
                 </div>
               ) : null}
             </React.Fragment>
@@ -77,7 +84,7 @@ export const CostSummary: React.FC<CostSummaryProps> = ({ fees, deposit, account
           ) : null}
 
           {/* Show success message ONLY if neither the main nor the proxy account is insufficient */}
-          {!hasInsufficientFunds && !hasProxyInsufficientFunds ? (
+          {!hasInsufficientFunds && (!hasProxyInsufficientFunds && !hasSignerInsufficientFunds) ? (
             <div className="text-green-600 font-bold flex items-center mt-3">
               The call will be successful.
             </div>

--- a/src/CostSummary/CostSummary.tsx
+++ b/src/CostSummary/CostSummary.tsx
@@ -8,18 +8,18 @@ interface CostSummaryProps {
   fees: bigint;
   deposit: bigint;
   accountBalance: bigint;
-  proxyAccountBalance?: bigint;
+  proxiedAccountBalance?: bigint;
   chainProperties: ChainProperties;  
 }
 
-export const CostSummary: React.FC<CostSummaryProps> = ({ fees, deposit, accountBalance, proxyAccountBalance, chainProperties }) => {
+export const CostSummary: React.FC<CostSummaryProps> = ({ fees, deposit, accountBalance, proxiedAccountBalance, chainProperties }) => {
   const [isOpen, setIsOpen] = useState(true);
 
   const totalCost = fees + deposit;
-  const isProxyUsed = proxyAccountBalance !== undefined;
+  const isProxyUsed = proxiedAccountBalance !== undefined;
 
   const hasInsufficientFunds = !isProxyUsed && accountBalance < totalCost;
-  const hasProxyInsufficientFunds = isProxyUsed && proxyAccountBalance < totalCost;
+  const hasProxyInsufficientFunds = isProxyUsed && proxiedAccountBalance < totalCost;
 
   return (
     <div className="mt-6 bg-gray-100 border border-gray-300 rounded-lg p-4">
@@ -54,12 +54,12 @@ export const CostSummary: React.FC<CostSummaryProps> = ({ fees, deposit, account
 
           {isProxyUsed && (
             <React.Fragment>
-              <CostItem title="Proxy Balance" amount={proxyAccountBalance!} chainProperties={chainProperties} />
+              <CostItem title="Proxy Balance" amount={proxiedAccountBalance!} chainProperties={chainProperties} />
               {hasProxyInsufficientFunds ? (
                 <div className="p-3 bg-red-100 border-l-4 border-red-500 text-red-700 rounded mt-3">
-                  <p className="font-semibold">Insufficient Proxy Balance</p>
-                  <p>The proxy doesn't have enough balance.</p>
-                  <p>You need at least <span className="font-bold">{formatCurrency(totalCost, chainProperties.tokenDecimals)} {chainProperties.tokenSymbol}</span> in the proxy account.</p>
+                  <p className="font-semibold">Insufficient Funds</p>
+                  <p>The proxied account doesn't have enough balance.</p>
+                  <p>You need at least <span className="font-bold">{formatCurrency(totalCost, chainProperties.tokenDecimals)} {chainProperties.tokenSymbol}</span> in the proxied account.</p>
                 </div>
               ) : null}
             </React.Fragment>

--- a/src/CostSummary/CostSummary.tsx
+++ b/src/CostSummary/CostSummary.tsx
@@ -18,8 +18,8 @@ export const CostSummary: React.FC<CostSummaryProps> = ({ fees, deposit, account
   const totalCost = fees + deposit;
   const isProxyUsed = proxyAccountBalance !== undefined;
 
-  const isInsufficientFunds = !isProxyUsed && accountBalance < totalCost;
-  const isProxyInsufficientFunds = isProxyUsed && proxyAccountBalance < totalCost;
+  const hasInsufficientFunds = !isProxyUsed && accountBalance < totalCost;
+  const hasProxyInsufficientFunds = isProxyUsed && proxyAccountBalance < totalCost;
 
   return (
     <div className="mt-6 bg-gray-100 border border-gray-300 rounded-lg p-4">
@@ -31,7 +31,7 @@ export const CostSummary: React.FC<CostSummaryProps> = ({ fees, deposit, account
           <h3 className="text-lg font-semibold">Cost Summary</h3>
         </div>
         <div className="flex items-center space-x-2">
-          {isInsufficientFunds || isProxyInsufficientFunds ? (
+          {hasInsufficientFunds || hasProxyInsufficientFunds ? (
             <div className="flex items-center space-x-2">
               <span className="text-red-600 font-medium">fails</span>
               <ErrorIcon size={8} />
@@ -55,7 +55,7 @@ export const CostSummary: React.FC<CostSummaryProps> = ({ fees, deposit, account
           {isProxyUsed && (
             <React.Fragment>
               <CostItem title="Proxy Balance" amount={proxyAccountBalance!} chainProperties={chainProperties} />
-              {isProxyInsufficientFunds ? (
+              {hasProxyInsufficientFunds ? (
                 <div className="p-3 bg-red-100 border-l-4 border-red-500 text-red-700 rounded mt-3">
                   <p className="font-semibold">Insufficient Proxy Balance</p>
                   <p>The proxy account does not have enough balance.</p>
@@ -66,7 +66,7 @@ export const CostSummary: React.FC<CostSummaryProps> = ({ fees, deposit, account
           )}
 
           {/* Only show this if the main account has insufficient funds AND there's no proxy */}
-          {!isProxyUsed && isInsufficientFunds ? (
+          {!isProxyUsed && hasInsufficientFunds ? (
             <div className="p-3 bg-red-100 border-l-4 border-red-500 text-red-700 rounded mt-3">
               <p className="font-semibold">Insufficient Funds</p>
               <p>You need at least <span className="font-bold">{formatCurrency(totalCost, chainProperties.tokenDecimals)} {chainProperties.tokenSymbol}</span> to complete this transaction.</p>
@@ -77,7 +77,7 @@ export const CostSummary: React.FC<CostSummaryProps> = ({ fees, deposit, account
           ) : null}
 
           {/* Show success message ONLY if neither the main nor the proxy account is insufficient */}
-          {!isInsufficientFunds && !isProxyInsufficientFunds ? (
+          {!hasInsufficientFunds && !hasProxyInsufficientFunds ? (
             <div className="text-green-600 font-bold flex items-center mt-3">
               The call will be successful.
             </div>

--- a/src/CostSummary/CostSummary.tsx
+++ b/src/CostSummary/CostSummary.tsx
@@ -58,7 +58,7 @@ export const CostSummary: React.FC<CostSummaryProps> = ({ fees, deposit, account
               {hasProxyInsufficientFunds ? (
                 <div className="p-3 bg-red-100 border-l-4 border-red-500 text-red-700 rounded mt-3">
                   <p className="font-semibold">Insufficient Proxy Balance</p>
-                  <p>The proxy account does not have enough balance.</p>
+                  <p>The proxy doesn't have enough balance.</p>
                   <p>You need at least <span className="font-bold">{formatCurrency(totalCost, chainProperties.tokenDecimals)} {chainProperties.tokenSymbol}</span> in the proxy account.</p>
                 </div>
               ) : null}

--- a/src/SigningPortal/SigningPortal.tsx
+++ b/src/SigningPortal/SigningPortal.tsx
@@ -45,7 +45,7 @@ export const SigningPortal: React.FC = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [signing, setSigning] = useState(false);
   const [balanceSelectedAccount, setBalanceSelectedAccount] = useState<bigint | null>(null);
-  const [proxyAccountBalance, setProxyAccountBalance] = useState<bigint | null>(null);
+  const [proxiedAccountBalance, setProxiedAccountBalance] = useState<bigint | null>(null);
 
   const [modalConfig, setModalConfig] = useState<{
     title: string;
@@ -264,7 +264,7 @@ export const SigningPortal: React.FC = () => {
     if (decodedCall.type === "Proxy" && decodedCall.value?.type === "proxy") {
       // @ts-ignore
       api.query.System.Account.watchValue(decodedCall.value?.value?.real.value).subscribe((ev) => {
-        setProxyAccountBalance(ev.data.free);
+        setProxiedAccountBalance(ev.data.free);
       });
       return decodedCall.value?.value?.call;
     }
@@ -456,7 +456,7 @@ export const SigningPortal: React.FC = () => {
                     deposit={deposit} 
                     accountBalance={balanceSelectedAccount as bigint}
                     chainProperties={chainProperties}
-                    proxyAccountBalance={proxyAccountBalance ?? undefined}
+                    proxiedAccountBalance={proxiedAccountBalance ?? undefined}
                   />
                 )}
               </React.Fragment>

--- a/src/SigningPortal/SigningPortal.tsx
+++ b/src/SigningPortal/SigningPortal.tsx
@@ -261,18 +261,19 @@ export const SigningPortal: React.FC = () => {
   // Extracts the actual Registrar call from the transaction registar, proxy, or sudo.
   const extractRegistrarCall = (tx: UnsafeTransaction<any, string, string, any>) => {
     let decodedCall = tx?.decodedCall;
+    let decodedCallValue = decodedCall.value?.value;
 
-    if (isRegistrarCall(tx.decodedCall)) return tx.decodedCall;
+    if (isRegistrarCall(decodedCall)) return decodedCall;
     if (decodedCall.type === "Proxy" && decodedCall.value?.type === "proxy") {
-      let account = decodedCall.value?.value?.real.value;
+      let account = decodedCallValue.real.value;
       setProxiedAccount(account);
       // @ts-ignore
       api.query.System.Account.watchValue(account).subscribe((ev) => {
         setProxiedAccountBalance(ev.data.free);
       });
-      return decodedCall.value?.value?.call;
+      return decodedCallValue.call;
     }
-    if (decodedCall.type === "Sudo" && decodedCall.value?.type === "sudo") return decodedCall.value?.value?.call;
+    if (decodedCall.type === "Sudo" && decodedCall.value?.type === "sudo") return decodedCallValue.call;
 
     return null;
   };

--- a/src/SigningPortal/SigningPortal.tsx
+++ b/src/SigningPortal/SigningPortal.tsx
@@ -45,7 +45,7 @@ export const SigningPortal: React.FC = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [signing, setSigning] = useState(false);
   const [balanceSelectedAccount, setBalanceSelectedAccount] = useState<bigint | null>(null);
-  const [proxyAccount, setProxyAccount] = useState<bigint | null>(null);
+  const [proxyAccountBalance, setProxyAccountBalance] = useState<bigint | null>(null);
 
   const [modalConfig, setModalConfig] = useState<{
     title: string;
@@ -257,7 +257,10 @@ export const SigningPortal: React.FC = () => {
 
     if (isRegistrarCall(tx.decodedCall)) return tx.decodedCall;
     if (decodedCall.type === "Proxy" && decodedCall.value?.type === "proxy") {
-      setProxyAccount(decodedCall.value?.value?.real.value);
+      // @ts-ignore
+      api.query.System.Account.watchValue(decodedCall.value?.value?.real.value).subscribe((ev) => {
+        setProxyAccountBalance(ev.data.free);
+      });
       return decodedCall.value?.value?.call;
     }
     if (decodedCall.type === "Sudo" && decodedCall.value?.type === "sudo") return decodedCall.value?.value?.call;
@@ -435,6 +438,7 @@ export const SigningPortal: React.FC = () => {
                     deposit={deposit} 
                     accountBalance={balanceSelectedAccount as bigint}
                     chainProperties={chainProperties}
+                    proxyAccountBalance={proxyAccountBalance ?? undefined}
                   />
                 )}
               </React.Fragment>

--- a/src/SigningPortal/SigningPortal.tsx
+++ b/src/SigningPortal/SigningPortal.tsx
@@ -45,7 +45,9 @@ export const SigningPortal: React.FC = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [signing, setSigning] = useState(false);
   const [balanceSelectedAccount, setBalanceSelectedAccount] = useState<bigint | null>(null);
+  const [proxiedAccount, setProxiedAccount] = useState<string | null>(null);
   const [proxiedAccountBalance, setProxiedAccountBalance] = useState<bigint | null>(null);
+
 
   const [modalConfig, setModalConfig] = useState<{
     title: string;
@@ -262,8 +264,10 @@ export const SigningPortal: React.FC = () => {
 
     if (isRegistrarCall(tx.decodedCall)) return tx.decodedCall;
     if (decodedCall.type === "Proxy" && decodedCall.value?.type === "proxy") {
+      let account = decodedCall.value?.value?.real.value;
+      setProxiedAccount(account);
       // @ts-ignore
-      api.query.System.Account.watchValue(decodedCall.value?.value?.real.value).subscribe((ev) => {
+      api.query.System.Account.watchValue(account).subscribe((ev) => {
         setProxiedAccountBalance(ev.data.free);
       });
       return decodedCall.value?.value?.call;
@@ -437,6 +441,14 @@ export const SigningPortal: React.FC = () => {
                   <span className="text-gray-600 font-light">Dispatchable:</span> {tx.decodedCall.value.type}
                 </div>
               </div>
+              {proxiedAccount && (
+                <div className="mt-2">
+                  <div className="text-gray-700 font-medium pb-1">Executing on behalf of:</div>
+                  <div className="bg-gray-50 rounded p-2 border border-gray-200 font-medium">
+                    <span className="text-gray-600 font-normal">Proxied Account:</span> {proxiedAccount}
+                  </div>
+                </div>
+              )}
               { isWrappedRegistrarCall(tx.decodedCall.type, tx.decodedCall.value) && (
                  <div className="mt-2 pl-4 border-l-2 border-gray-300">
                   <div className="text-gray-700 font-medium pb-1">Underlying Call:</div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -36,7 +36,7 @@ export type FormatCurrencyOptions = {
 }
 
 const defaultOptions: FormatCurrencyOptions = {
-  nDecimals: Infinity,
+  nDecimals: 2,
   padToDecimals: true,
   decimalSeparator: decimalSeparatorDisplay,
 }


### PR DESCRIPTION
This PR improves upon the previous one: https://github.com/r0gue-io/pop-wallet-signing-portal/pull/7

- It handles cases where the reserve/register call is made via a proxy, which I noticed while working on: https://github.com/r0gue-io/pop-cli/pull/427 in pop-cli
- It also includes support for sudo calls, allowing pop call to handle registrations made using sudo.

**Screenshots**

`Insufficient funds in the proxy `

![Captura de pantalla 2025-02-28 a las 13 25 09](https://github.com/user-attachments/assets/5c56e3da-e3a9-4483-bfbf-40887f558487)


`Sufficient funds in the proxy`

![Captura de pantalla 2025-02-28 a las 13 23 46](https://github.com/user-attachments/assets/b39267c7-31c1-4ca7-a57d-f74941ad18de)


`Sudo`

![Captura de pantalla 2025-02-28 a las 13 27 01](https://github.com/user-attachments/assets/e43a87e1-73d9-4ceb-b9b8-b0cd03f9cf46)


`The normal flow hasn't change`

![Captura de pantalla 2025-02-27 a las 18 03 34](https://github.com/user-attachments/assets/accd33f3-219c-444d-bad0-ab3c8868acc1)

