### PR TITLE
feat: calculate contract address after pallet_revive deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "dot-connect": "^0.13.2",
+    "ethers": "^6.13.5",
     "lucide-react": "^0.456.0",
     "polkadot-api": "^1.7.3",
     "react": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@polkadot-ui/react':
         specifier: 0.0.1-alpha.35
-        version: 0.0.1-alpha.35(@noble/hashes@1.7.1)(@polkadot-api/substrate-bindings@0.11.1)(@polkadot-ui/assets@0.0.1-alpha.2)(@polkadot-ui/core@0.0.1-alpha.2)(@polkadot-ui/utils@0.0.3(@polkadot/keyring@12.6.2(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2))(@polkadot/util@12.6.2))(polkadot-api@1.9.7(jiti@1.21.6)(postcss@8.4.49)(rxjs@7.8.1)(yaml@2.6.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 0.0.1-alpha.35(@noble/hashes@1.7.1)(@polkadot-api/substrate-bindings@0.11.1)(@polkadot-ui/assets@0.0.1-alpha.2)(@polkadot-ui/core@0.0.1-alpha.2)(@polkadot-ui/utils@0.0.3(@polkadot/keyring@13.4.4(@polkadot/util-crypto@12.6.2(@polkadot/util@13.4.4))(@polkadot/util@13.4.4))(@polkadot/util@13.4.4))(polkadot-api@1.9.7(jiti@1.21.6)(postcss@8.4.49)(rxjs@7.8.1)(yaml@2.6.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dialog':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -44,6 +44,9 @@ importers:
       dot-connect:
         specifier: ^0.13.2
         version: 0.13.2(@reactive-dot/core@0.27.1(polkadot-api@1.9.7(jiti@1.21.6)(postcss@8.4.49)(rxjs@7.8.1)(yaml@2.6.0)))(@types/react@18.3.12)(react@18.3.1)
+      ethers:
+        specifier: ^6.13.5
+        version: 6.13.5
       lucide-react:
         specifier: ^0.456.0
         version: 0.456.0(react@18.3.1)
@@ -113,6 +116,9 @@ importers:
         version: 2.1.0(rollup@4.37.0)(vite@5.4.11(@types/node@22.9.0)(lightningcss@1.28.2)(terser@5.37.0))
 
 packages:
+
+  '@adraffy/ens-normalize@1.10.1':
+    resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -551,9 +557,16 @@ packages:
   '@lit/task@1.0.1':
     resolution: {integrity: sha512-fVLDtmwCau8NywnFIXaJxsCZjzaIxnVq+cFRKYC1Y4tA4/0rMTvF6DLZZ2JE51BwzOluaKtgJX8x1QDsQtAaIw==}
 
+  '@noble/curves@1.2.0':
+    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
+
   '@noble/curves@1.7.0':
     resolution: {integrity: sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.3.2':
+    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
+    engines: {node: '>= 16'}
 
   '@noble/hashes@1.5.0':
     resolution: {integrity: sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==}
@@ -679,12 +692,12 @@ packages:
       '@polkadot/keyring': ^12.6.2
       '@polkadot/util': ^12.6.2
 
-  '@polkadot/keyring@12.6.2':
-    resolution: {integrity: sha512-O3Q7GVmRYm8q7HuB3S0+Yf/q/EB2egKRRU3fv9b3B7V+A52tKzA+vIwEmNVaD1g5FKW9oB97rmpggs0zaKFqHw==}
+  '@polkadot/keyring@13.4.4':
+    resolution: {integrity: sha512-pIm+u1lat+mGUABsCZyTm1/qgwL3NS94SC7TPtSzhzFZq6faUFNMyq1gBfTicrb7MjGFc8FlrKlGxFtudnQC9Q==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@polkadot/util': 12.6.2
-      '@polkadot/util-crypto': 12.6.2
+      '@polkadot/util': 13.4.4
+      '@polkadot/util-crypto': 13.4.4
 
   '@polkadot/networks@12.6.2':
     resolution: {integrity: sha512-1oWtZm1IvPWqvMrldVH6NI2gBoCndl5GEwx7lAuQWGr7eNL+6Bdc5K3Z9T0MzFvDGoi2/CBqjX9dRKo39pDC/w==}
@@ -698,6 +711,10 @@ packages:
 
   '@polkadot/util@12.6.2':
     resolution: {integrity: sha512-l8TubR7CLEY47240uki0TQzFvtnxFIO7uI/0GoWzpYD/O62EIAMRsuY01N4DuwgKq2ZWD59WhzsLYmA5K6ksdw==}
+    engines: {node: '>=18'}
+
+  '@polkadot/util@13.4.4':
+    resolution: {integrity: sha512-Lveu+8pZLBoAyyv+8X7FI4aTOwLaNXRc9gz1wVaUoGzk5VgmKp/qbPg0a+mfJD8usjf748OVbShhjXvhV3MLiA==}
     engines: {node: '>=18'}
 
   '@polkadot/wasm-bridge@7.4.1':
@@ -743,8 +760,16 @@ packages:
     resolution: {integrity: sha512-HSIk60uFPX4GOFZSnIF7VYJz7WZA7tpFJsne7SzxOooRwMTWEtw3fUpFy5cYYOeLh17/kHH1Y7SVcuxzVLc74Q==}
     engines: {node: '>=18'}
 
+  '@polkadot/x-bigint@13.4.4':
+    resolution: {integrity: sha512-XjChwagc8TbIoWx9N1JwCMOyte417ngobin6vTmLQsgaOlK84LU0/3uc0ea9qUurPopc/Spf1mSMOFp7lRBrIA==}
+    engines: {node: '>=18'}
+
   '@polkadot/x-global@12.6.2':
     resolution: {integrity: sha512-a8d6m+PW98jmsYDtAWp88qS4dl8DyqUBsd0S+WgyfSMtpEXu6v9nXDgPZgwF5xdDvXhm+P0ZfVkVTnIGrScb5g==}
+    engines: {node: '>=18'}
+
+  '@polkadot/x-global@13.4.4':
+    resolution: {integrity: sha512-kwXpzTXOgL2GdMWMzynj9ZpZdjfNvDlpQdlWzDNqTBeIeuklhmhDCA7ZFj3p5OkNUnZoTxNj4zgArYO3VKmQ1g==}
     engines: {node: '>=18'}
 
   '@polkadot/x-randomvalues@12.6.2':
@@ -758,8 +783,16 @@ packages:
     resolution: {integrity: sha512-M1Bir7tYvNappfpFWXOJcnxUhBUFWkUFIdJSyH0zs5LmFtFdbKAeiDXxSp2Swp5ddOZdZgPac294/o2TnQKN1w==}
     engines: {node: '>=18'}
 
+  '@polkadot/x-textdecoder@13.4.4':
+    resolution: {integrity: sha512-fXvM2ts0IUx6F/Fd1Yg4ypHCffmUtTSwOtFpqBPvWghKYnmvTbGVrSidGizu6as7KAp4dsum9mYKdRmScBHHzg==}
+    engines: {node: '>=18'}
+
   '@polkadot/x-textencoder@12.6.2':
     resolution: {integrity: sha512-4N+3UVCpI489tUJ6cv3uf0PjOHvgGp9Dl+SZRLgFGt9mvxnvpW/7+XBADRMtlG4xi5gaRK7bgl5bmY6OMDsNdw==}
+    engines: {node: '>=18'}
+
+  '@polkadot/x-textencoder@13.4.4':
+    resolution: {integrity: sha512-WpPR2vMAiXS2AN8MfolzWbo5WPEmy5FVZFgwZraJZP8RKfzEuntbY5Nb25p/PIjsPJ1zKU0DE8uVvDcGjxIo7A==}
     engines: {node: '>=18'}
 
   '@preact/signals-core@1.8.0':
@@ -1494,6 +1527,9 @@ packages:
   '@types/node@22.13.13':
     resolution: {integrity: sha512-ClsL5nMwKaBRwPcCvH8E7+nU4GxHVx1axNvMZTFHMEfNI7oahimt26P5zjVCRrjiIWj6YFXfE1v3dEp94wLcGQ==}
 
+  '@types/node@22.7.5':
+    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
+
   '@types/node@22.9.0':
     resolution: {integrity: sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==}
 
@@ -1522,6 +1558,9 @@ packages:
     resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  aes-js@4.0.0-beta.5:
+    resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1777,6 +1816,10 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  ethers@6.13.5:
+    resolution: {integrity: sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ==}
+    engines: {node: '>=14.0.0'}
 
   execa@9.5.2:
     resolution: {integrity: sha512-EHlpxMCpHWSAh1dgS6bVeoLAXGnJNdR93aabr4QCGbzOM73o5XmRfM/e5FUqsw3aagP8S8XEWUWFAxnRBnAF0Q==}
@@ -2598,6 +2641,9 @@ packages:
     peerDependencies:
       typescript: '>=4'
 
+  tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -2767,6 +2813,18 @@ packages:
     resolution: {integrity: sha512-DqUx8GI3r9BFWwU2DPKddL1E7xWfbFED82mLVhGXKlFEPe8IkBftzO7WfNwHtk7oGDHDeuH/o8VMpzzfMwmLUA==}
     engines: {node: '>=18'}
 
+  ws@8.17.1:
+    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   ws@8.18.1:
     resolution: {integrity: sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==}
     engines: {node: '>=10.0.0'}
@@ -2815,6 +2873,8 @@ packages:
     engines: {node: '>=18'}
 
 snapshots:
+
+  '@adraffy/ens-normalize@1.10.1': {}
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -3149,9 +3209,15 @@ snapshots:
     dependencies:
       '@lit/reactive-element': 2.0.4
 
+  '@noble/curves@1.2.0':
+    dependencies:
+      '@noble/hashes': 1.3.2
+
   '@noble/curves@1.7.0':
     dependencies:
       '@noble/hashes': 1.6.0
+
+  '@noble/hashes@1.3.2': {}
 
   '@noble/hashes@1.5.0': {}
 
@@ -3335,26 +3401,26 @@ snapshots:
 
   '@polkadot-ui/core@0.0.1-alpha.2': {}
 
-  '@polkadot-ui/react@0.0.1-alpha.35(@noble/hashes@1.7.1)(@polkadot-api/substrate-bindings@0.11.1)(@polkadot-ui/assets@0.0.1-alpha.2)(@polkadot-ui/core@0.0.1-alpha.2)(@polkadot-ui/utils@0.0.3(@polkadot/keyring@12.6.2(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2))(@polkadot/util@12.6.2))(polkadot-api@1.9.7(jiti@1.21.6)(postcss@8.4.49)(rxjs@7.8.1)(yaml@2.6.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@polkadot-ui/react@0.0.1-alpha.35(@noble/hashes@1.7.1)(@polkadot-api/substrate-bindings@0.11.1)(@polkadot-ui/assets@0.0.1-alpha.2)(@polkadot-ui/core@0.0.1-alpha.2)(@polkadot-ui/utils@0.0.3(@polkadot/keyring@13.4.4(@polkadot/util-crypto@12.6.2(@polkadot/util@13.4.4))(@polkadot/util@13.4.4))(@polkadot/util@13.4.4))(polkadot-api@1.9.7(jiti@1.21.6)(postcss@8.4.49)(rxjs@7.8.1)(yaml@2.6.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@noble/hashes': 1.7.1
       '@polkadot-api/substrate-bindings': 0.11.1
       '@polkadot-ui/assets': 0.0.1-alpha.2
       '@polkadot-ui/core': 0.0.1-alpha.2
-      '@polkadot-ui/utils': 0.0.3(@polkadot/keyring@12.6.2(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)
+      '@polkadot-ui/utils': 0.0.3(@polkadot/keyring@13.4.4(@polkadot/util-crypto@12.6.2(@polkadot/util@13.4.4))(@polkadot/util@13.4.4))(@polkadot/util@13.4.4)
       polkadot-api: 1.9.7(jiti@1.21.6)(postcss@8.4.49)(rxjs@7.8.1)(yaml@2.6.0)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@polkadot-ui/utils@0.0.3(@polkadot/keyring@12.6.2(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)':
+  '@polkadot-ui/utils@0.0.3(@polkadot/keyring@13.4.4(@polkadot/util-crypto@12.6.2(@polkadot/util@13.4.4))(@polkadot/util@13.4.4))(@polkadot/util@13.4.4)':
     dependencies:
-      '@polkadot/keyring': 12.6.2(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)
-      '@polkadot/util': 12.6.2
+      '@polkadot/keyring': 13.4.4(@polkadot/util-crypto@12.6.2(@polkadot/util@13.4.4))(@polkadot/util@13.4.4)
+      '@polkadot/util': 13.4.4
 
-  '@polkadot/keyring@12.6.2(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)':
+  '@polkadot/keyring@13.4.4(@polkadot/util-crypto@12.6.2(@polkadot/util@13.4.4))(@polkadot/util@13.4.4)':
     dependencies:
-      '@polkadot/util': 12.6.2
-      '@polkadot/util-crypto': 12.6.2(@polkadot/util@12.6.2)
+      '@polkadot/util': 13.4.4
+      '@polkadot/util-crypto': 12.6.2(@polkadot/util@13.4.4)
       tslib: 2.8.1
 
   '@polkadot/networks@12.6.2':
@@ -3363,16 +3429,16 @@ snapshots:
       '@substrate/ss58-registry': 1.51.0
       tslib: 2.8.1
 
-  '@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2)':
+  '@polkadot/util-crypto@12.6.2(@polkadot/util@13.4.4)':
     dependencies:
       '@noble/curves': 1.7.0
       '@noble/hashes': 1.7.1
       '@polkadot/networks': 12.6.2
-      '@polkadot/util': 12.6.2
-      '@polkadot/wasm-crypto': 7.4.1(@polkadot/util@12.6.2)(@polkadot/x-randomvalues@12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2)))
-      '@polkadot/wasm-util': 7.4.1(@polkadot/util@12.6.2)
+      '@polkadot/util': 13.4.4
+      '@polkadot/wasm-crypto': 7.4.1(@polkadot/util@13.4.4)(@polkadot/x-randomvalues@12.6.2(@polkadot/util@13.4.4)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.4)))
+      '@polkadot/wasm-util': 7.4.1(@polkadot/util@13.4.4)
       '@polkadot/x-bigint': 12.6.2
-      '@polkadot/x-randomvalues': 12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2))
+      '@polkadot/x-randomvalues': 12.6.2(@polkadot/util@13.4.4)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.4))
       '@scure/base': 1.2.4
       tslib: 2.8.1
 
@@ -3386,48 +3452,58 @@ snapshots:
       bn.js: 5.2.1
       tslib: 2.8.1
 
-  '@polkadot/wasm-bridge@7.4.1(@polkadot/util@12.6.2)(@polkadot/x-randomvalues@12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2)))':
+  '@polkadot/util@13.4.4':
     dependencies:
-      '@polkadot/util': 12.6.2
-      '@polkadot/wasm-util': 7.4.1(@polkadot/util@12.6.2)
-      '@polkadot/x-randomvalues': 12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2))
+      '@polkadot/x-bigint': 13.4.4
+      '@polkadot/x-global': 13.4.4
+      '@polkadot/x-textdecoder': 13.4.4
+      '@polkadot/x-textencoder': 13.4.4
+      '@types/bn.js': 5.1.6
+      bn.js: 5.2.1
       tslib: 2.8.1
 
-  '@polkadot/wasm-crypto-asmjs@7.4.1(@polkadot/util@12.6.2)':
+  '@polkadot/wasm-bridge@7.4.1(@polkadot/util@13.4.4)(@polkadot/x-randomvalues@12.6.2(@polkadot/util@13.4.4)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.4)))':
     dependencies:
-      '@polkadot/util': 12.6.2
+      '@polkadot/util': 13.4.4
+      '@polkadot/wasm-util': 7.4.1(@polkadot/util@13.4.4)
+      '@polkadot/x-randomvalues': 12.6.2(@polkadot/util@13.4.4)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.4))
       tslib: 2.8.1
 
-  '@polkadot/wasm-crypto-init@7.4.1(@polkadot/util@12.6.2)(@polkadot/x-randomvalues@12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2)))':
+  '@polkadot/wasm-crypto-asmjs@7.4.1(@polkadot/util@13.4.4)':
     dependencies:
-      '@polkadot/util': 12.6.2
-      '@polkadot/wasm-bridge': 7.4.1(@polkadot/util@12.6.2)(@polkadot/x-randomvalues@12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2)))
-      '@polkadot/wasm-crypto-asmjs': 7.4.1(@polkadot/util@12.6.2)
-      '@polkadot/wasm-crypto-wasm': 7.4.1(@polkadot/util@12.6.2)
-      '@polkadot/wasm-util': 7.4.1(@polkadot/util@12.6.2)
-      '@polkadot/x-randomvalues': 12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2))
+      '@polkadot/util': 13.4.4
       tslib: 2.8.1
 
-  '@polkadot/wasm-crypto-wasm@7.4.1(@polkadot/util@12.6.2)':
+  '@polkadot/wasm-crypto-init@7.4.1(@polkadot/util@13.4.4)(@polkadot/x-randomvalues@12.6.2(@polkadot/util@13.4.4)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.4)))':
     dependencies:
-      '@polkadot/util': 12.6.2
-      '@polkadot/wasm-util': 7.4.1(@polkadot/util@12.6.2)
+      '@polkadot/util': 13.4.4
+      '@polkadot/wasm-bridge': 7.4.1(@polkadot/util@13.4.4)(@polkadot/x-randomvalues@12.6.2(@polkadot/util@13.4.4)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.4)))
+      '@polkadot/wasm-crypto-asmjs': 7.4.1(@polkadot/util@13.4.4)
+      '@polkadot/wasm-crypto-wasm': 7.4.1(@polkadot/util@13.4.4)
+      '@polkadot/wasm-util': 7.4.1(@polkadot/util@13.4.4)
+      '@polkadot/x-randomvalues': 12.6.2(@polkadot/util@13.4.4)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.4))
       tslib: 2.8.1
 
-  '@polkadot/wasm-crypto@7.4.1(@polkadot/util@12.6.2)(@polkadot/x-randomvalues@12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2)))':
+  '@polkadot/wasm-crypto-wasm@7.4.1(@polkadot/util@13.4.4)':
     dependencies:
-      '@polkadot/util': 12.6.2
-      '@polkadot/wasm-bridge': 7.4.1(@polkadot/util@12.6.2)(@polkadot/x-randomvalues@12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2)))
-      '@polkadot/wasm-crypto-asmjs': 7.4.1(@polkadot/util@12.6.2)
-      '@polkadot/wasm-crypto-init': 7.4.1(@polkadot/util@12.6.2)(@polkadot/x-randomvalues@12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2)))
-      '@polkadot/wasm-crypto-wasm': 7.4.1(@polkadot/util@12.6.2)
-      '@polkadot/wasm-util': 7.4.1(@polkadot/util@12.6.2)
-      '@polkadot/x-randomvalues': 12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2))
+      '@polkadot/util': 13.4.4
+      '@polkadot/wasm-util': 7.4.1(@polkadot/util@13.4.4)
       tslib: 2.8.1
 
-  '@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2)':
+  '@polkadot/wasm-crypto@7.4.1(@polkadot/util@13.4.4)(@polkadot/x-randomvalues@12.6.2(@polkadot/util@13.4.4)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.4)))':
     dependencies:
-      '@polkadot/util': 12.6.2
+      '@polkadot/util': 13.4.4
+      '@polkadot/wasm-bridge': 7.4.1(@polkadot/util@13.4.4)(@polkadot/x-randomvalues@12.6.2(@polkadot/util@13.4.4)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.4)))
+      '@polkadot/wasm-crypto-asmjs': 7.4.1(@polkadot/util@13.4.4)
+      '@polkadot/wasm-crypto-init': 7.4.1(@polkadot/util@13.4.4)(@polkadot/x-randomvalues@12.6.2(@polkadot/util@13.4.4)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.4)))
+      '@polkadot/wasm-crypto-wasm': 7.4.1(@polkadot/util@13.4.4)
+      '@polkadot/wasm-util': 7.4.1(@polkadot/util@13.4.4)
+      '@polkadot/x-randomvalues': 12.6.2(@polkadot/util@13.4.4)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.4))
+      tslib: 2.8.1
+
+  '@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.4)':
+    dependencies:
+      '@polkadot/util': 13.4.4
       tslib: 2.8.1
 
   '@polkadot/x-bigint@12.6.2':
@@ -3435,14 +3511,23 @@ snapshots:
       '@polkadot/x-global': 12.6.2
       tslib: 2.8.1
 
+  '@polkadot/x-bigint@13.4.4':
+    dependencies:
+      '@polkadot/x-global': 13.4.4
+      tslib: 2.8.1
+
   '@polkadot/x-global@12.6.2':
     dependencies:
       tslib: 2.8.1
 
-  '@polkadot/x-randomvalues@12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2))':
+  '@polkadot/x-global@13.4.4':
     dependencies:
-      '@polkadot/util': 12.6.2
-      '@polkadot/wasm-util': 7.4.1(@polkadot/util@12.6.2)
+      tslib: 2.8.1
+
+  '@polkadot/x-randomvalues@12.6.2(@polkadot/util@13.4.4)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.4))':
+    dependencies:
+      '@polkadot/util': 13.4.4
+      '@polkadot/wasm-util': 7.4.1(@polkadot/util@13.4.4)
       '@polkadot/x-global': 12.6.2
       tslib: 2.8.1
 
@@ -3451,9 +3536,19 @@ snapshots:
       '@polkadot/x-global': 12.6.2
       tslib: 2.8.1
 
+  '@polkadot/x-textdecoder@13.4.4':
+    dependencies:
+      '@polkadot/x-global': 13.4.4
+      tslib: 2.8.1
+
   '@polkadot/x-textencoder@12.6.2':
     dependencies:
       '@polkadot/x-global': 12.6.2
+      tslib: 2.8.1
+
+  '@polkadot/x-textencoder@13.4.4':
+    dependencies:
+      '@polkadot/x-global': 13.4.4
       tslib: 2.8.1
 
   '@preact/signals-core@1.8.0': {}
@@ -4093,6 +4188,10 @@ snapshots:
     dependencies:
       undici-types: 6.20.0
 
+  '@types/node@22.7.5':
+    dependencies:
+      undici-types: 6.19.8
+
   '@types/node@22.9.0':
     dependencies:
       undici-types: 6.19.8
@@ -4125,6 +4224,8 @@ snapshots:
 
   acorn@8.14.0:
     optional: true
+
+  aes-js@4.0.0-beta.5: {}
 
   ansi-regex@5.0.1: {}
 
@@ -4384,6 +4485,19 @@ snapshots:
       '@esbuild/win32-x64': 0.25.1
 
   escalade@3.2.0: {}
+
+  ethers@6.13.5:
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.1
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@types/node': 22.7.5
+      aes-js: 4.0.0-beta.5
+      tslib: 2.7.0
+      ws: 8.17.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   execa@9.5.2:
     dependencies:
@@ -5191,6 +5305,8 @@ snapshots:
     dependencies:
       typescript: 5.8.2
 
+  tslib@2.7.0: {}
+
   tslib@2.8.1: {}
 
   tsup@8.4.0(jiti@1.21.6)(postcss@8.4.49)(typescript@5.8.2)(yaml@2.6.0):
@@ -5345,6 +5461,8 @@ snapshots:
       sort-keys: 5.1.0
       type-fest: 4.26.1
       write-json-file: 6.0.0
+
+  ws@8.17.1: {}
 
   ws@8.18.1: {}
 

--- a/src/api/useBackendAPI.ts
+++ b/src/api/useBackendAPI.ts
@@ -9,6 +9,11 @@ export interface Response {
   status: string
 }
 
+export interface SubmitData {
+  signed_payload: string | undefined;
+  contract_address: string | undefined;
+}
+
 // Define types for API responses
 type SubmitResponse = Response;
 
@@ -23,7 +28,7 @@ const useBackendAPI = () => {
   }, []);
 
   const submitData = useCallback(
-    async (data: string | undefined): Promise<SubmitResponse> => {
+    async (data: SubmitData): Promise<SubmitResponse> => {
       const response = await fetch(`${BASE_URL}/submit`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/src/lib/contractAddress.ts
+++ b/src/lib/contractAddress.ts
@@ -13,8 +13,8 @@ export async function calculateContractAddress(
     salt: string,
   ): Promise<string | undefined> {
     let calculatedAddress: string | undefined = undefined;
-    const acIdEnc = AccountId()[0];
-    const mappedAccount = toEthAddress(acIdEnc(accountId));
+    const accountIdEncoded = AccountId()[0];
+    const mappedAccount = toEthAddress(accountIdEncoded(accountId));
     if (salt) {
         // Use CREATE2
         calculatedAddress = create2(mappedAccount, fromHex(code), data, salt);
@@ -24,7 +24,6 @@ export async function calculateContractAddress(
          // Use CREATE1
         if (nonce !== null) {
             calculatedAddress = create1(mappedAccount, nonce);
-            console.log("calculatedAddress", calculatedAddress);
         }
     }
     return calculatedAddress;

--- a/src/lib/contractAddress.ts
+++ b/src/lib/contractAddress.ts
@@ -1,0 +1,115 @@
+import { BigNumberish, ethers, keccak256 } from 'ethers';
+import { UnsafeApi, AccountId } from "polkadot-api"
+import { fromHex } from "polkadot-api/utils";
+
+/**
+ * Calculates the expected Ethereum-style contract address using CREATE or CREATE2 logic.
+ */
+export async function calculateContractAddress(
+    api: UnsafeApi<any>,
+    accountId: string,
+    code: string, 
+    data: Uint8Array,
+    salt: string,
+  ): Promise<string | undefined> {
+    let calculatedAddress: string | undefined = undefined;
+    const acIdEnc = AccountId()[0];
+    const mappedAccount = toEthAddress(acIdEnc(accountId));
+    if (salt) {
+        // Use CREATE2
+        calculatedAddress = create2(mappedAccount, fromHex(code), data, salt);
+    } else {
+        // @ts-ignore
+        const nonce = await api.apis.AccountNonceApi.account_nonce(accountId);
+         // Use CREATE1
+        if (nonce !== null) {
+            calculatedAddress = create1(mappedAccount, nonce);
+            console.log("calculatedAddress", calculatedAddress);
+        }
+    }
+    return calculatedAddress;
+}
+
+/**
+ * TypeScript equivalent of H160 (20-byte Ethereum address)
+ */
+type Address = string;
+
+/**
+ * Determine the address of a contract using CREATE semantics.
+ * @param deployer The address of the deployer
+ * @param nonce The nonce value
+ * @returns The contract address
+ */
+function create1(deployer: string, nonce: number): Address {
+  // Convert deployer to bytes (remove 0x prefix if present)
+  const deployerBytes = ethers.hexlify(deployer);
+  ethers.toBeHex(nonce as BigNumberish);
+  // Convert nonce to hex (minimal encoding)
+  const nonceBytes = ethers.toBeHex(nonce as BigNumberish);
+
+  // RLP encode [deployer, nonce]
+  const encodedData = ethers.encodeRlp([deployerBytes, nonceBytes]);
+
+  // Calculate keccak256 hash of the RLP encoded data
+  const hash = ethers.keccak256(encodedData);
+
+  // Take the last 20 bytes (40 hex chars + 0x prefix)
+  return ethers.getAddress('0x' + hash.substring(26));
+}
+
+function create2(
+  deployer: string,
+  code: Uint8Array,
+  inputData: Uint8Array,
+  salt: string,
+): string {
+  const initCode = new Uint8Array([...code, ...inputData]);
+  const initCodeHash = fromHex(keccak256(initCode));
+
+  const parts = new Uint8Array(1 + 20 + 32 + 32); // 0xff + deployer + salt + initCodeHash
+  parts[0] = 0xff;
+  parts.set(fromHex(deployer), 1);
+  parts.set(fromHex(salt), 21);
+  parts.set(initCodeHash, 53);
+
+  const hash = keccak256(parts);
+
+  // Return last 20 bytes as 0x-prefixed hex string
+  return ethers.getAddress('0x' + hash.substring(26));
+}
+
+/**
+ * Determines if an account ID is derived from an Ethereum address
+ * @param accountId The account ID bytes
+ * @returns True if the account is derived from an Ethereum address
+ */
+export function isEthDerived(accountId: Uint8Array): boolean {
+    if (accountId.length >= 32) {
+      return accountId[20] === 0xee && accountId[21] === 0xee;
+    }
+    return false;
+  }
+
+/**
+ * Converts an account ID to an Ethereum address (H160)
+ * @param accountId The account ID bytes
+ * @returns The Ethereum address
+ */
+export function toEthAddress(accountBytes: Uint8Array): string {
+  
+    // Create a 32-byte buffer and copy account bytes into it
+    const accountBuffer = new Uint8Array(32);
+    accountBuffer.set(accountBytes.slice(0, 32));
+  
+    if (isEthDerived(accountBytes)) {
+      // This was originally an eth address
+      // We just strip the 0xEE suffix to get the original address
+      return '0x' + Buffer.from(accountBuffer.slice(0, 20)).toString('hex');
+    } else {
+      // This is an (ed|sr)25519 derived address
+      // Avoid truncating the public key by hashing it first
+      const accountHash = ethers.keccak256(accountBuffer);
+      return ethers.getAddress('0x' + accountHash.slice(2 + 24, 2 + 24 + 40)); // Skip '0x' prefix, then skip 12 bytes, take 20 bytes
+    }
+  }


### PR DESCRIPTION
Adds support for calculating the smart contract address for pallet-revive deployment and submit the value.

The implementation follows the same logic used in cargo-contracts and contracts UI:
- cargo-contract https://github.com/use-ink/cargo-contract/blob/master/crates/extrinsics/src/instantiate.rs#L634
- contracts-ui https://github.com/use-ink/contracts-ui/blob/426b6fddbd1fd2f409f2937f2ef8e3cab0e1c921/src/ui/hooks/useNewContract.ts#L160C6-L179C8

Corresponding changes in `pop-cli` for fetching the address can be found in this commit: https://github.com/r0gue-io/pop-cli/pull/500/commits/3b7e05967910dd0075688c9aa78e5b071672d1d5

**To test it** 
Install `pop-cli` from the `feat/revive-compatibility-with-flags` branch with the `polkavm-contracts` feature flag:
```
cargo install --git https://github.com/r0gue-io/pop-cli.git --branch  feat/revive-compatibility-with-flags --no-default-features --locked -F polkavm-contracts,parachain
```
And in your contract run `pop up` with `--use-wallet` feature.

[sc-3688]